### PR TITLE
Feature/constraint naming rules

### DIFF
--- a/src/sqlfluff/rules/convention/CV13.py
+++ b/src/sqlfluff/rules/convention/CV13.py
@@ -1,0 +1,98 @@
+"""Implementation of Rule CV13."""
+
+from typing import Optional
+
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+
+class Rule_CV13(BaseRule):
+    """PRIMARY KEY constraint names should use expected prefix.
+
+    **Anti-pattern**
+
+    .. code-block:: sql
+
+        CREATE TABLE public.person (
+            person_id INT,
+            CONSTRAINT person_pk PRIMARY KEY (person_id)
+        );
+
+    **Best practice**
+
+    .. code-block:: sql
+
+        CREATE TABLE public.person (
+            person_id INT,
+            CONSTRAINT pk_person PRIMARY KEY (person_id)
+        );
+    """
+
+    name = "convention.constraint_name.primary_key"
+    code = "CV13"
+    description = "Enforces PRIMARY KEY constraints to start with expected prefix."
+    groups = ("all", "convention")
+    config_keywords = []
+    crawl_behaviour = SegmentSeekerCrawler({"table_constraint"})
+
+    # The expected prefix for PRIMARY KEY constraint
+    _DEFAULT_EXPECTED_PREFIX = "pk_"
+
+    def __init__(self, code="CV13", description="", **kwargs):
+        """Initialize the rule with configuration."""
+        super().__init__(code=code, description=description, **kwargs)
+        # Set default expected_prefix if not provided
+        self.expected_prefix = kwargs.get(
+            "expected_prefix", self._DEFAULT_EXPECTED_PREFIX
+        )
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        """Validate PRIMARY KEY constraint name prefixes."""
+        try:
+            segment = context.segment
+            obj_ref = segment.get_child("object_reference")
+            if not obj_ref:
+                return None
+
+            constraint_name = obj_ref.raw
+            keywords = [
+                keyword.raw.upper() for keyword in segment.get_children("keyword")
+            ]
+
+            # Check if this is a PRIMARY KEY constraint
+            is_primary_key = {"PRIMARY", "KEY"}.issubset(keywords)
+
+            if is_primary_key and not constraint_name.lower().startswith(
+                self.expected_prefix
+            ):
+                return self._create_lint_result(
+                    segment, constraint_name, self.expected_prefix
+                )
+            return None
+        except Exception as e:
+            self.logger.error(f"Exception in constraint naming rule: {str(e)}")
+            return None
+
+    def _create_lint_result(
+        self, segment, constraint_name: str, expected_prefix: str
+    ) -> LintResult:
+        """Create a lint result for a constraint naming violation.
+
+        Args:
+            segment: The segment to anchor the lint result to
+            constraint_name: The name of the constraint
+            expected_prefix: The expected prefix for the constraint
+
+        Returns:
+            LintResult: The lint result object
+        """
+        self.logger.debug(
+            f"PRIMARY KEY constraint '{constraint_name}' violates convention"
+        )
+        return LintResult(
+            anchor=segment,
+            description=(
+                f"PRIMARY KEY constraint name '{constraint_name}' should start with "
+                f"'{expected_prefix}'."
+            ),
+        )

--- a/src/sqlfluff/rules/convention/CV14.py
+++ b/src/sqlfluff/rules/convention/CV14.py
@@ -1,0 +1,102 @@
+"""Implementation of Rule CV14."""
+
+from typing import Optional
+
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+
+class Rule_CV14(BaseRule):
+    """FOREIGN KEY constraint names should use expected prefix.
+
+    **Anti-pattern**
+
+    .. code-block:: sql
+
+        CREATE TABLE public.orders (
+            order_id INT,
+            customer_id INT,
+            CONSTRAINT customer_order_fkey FOREIGN KEY (customer_id)
+                REFERENCES public.customers(id)
+        );
+
+    **Best practice**
+
+    .. code-block:: sql
+
+        CREATE TABLE public.orders (
+            order_id INT,
+            customer_id INT,
+            CONSTRAINT fk_customer_order FOREIGN KEY (customer_id)
+                REFERENCES public.customers(id)
+        );
+    """
+
+    name = "convention.constraint_name.foreign_key"
+    code = "CV14"
+    description = "Enforces FOREIGN KEY constraints to start with expected prefix."
+    groups = ("all", "convention")
+    config_keywords = []
+    crawl_behaviour = SegmentSeekerCrawler({"table_constraint"})
+
+    # The expected prefix for FOREIGN KEY constraint
+    _DEFAULT_EXPECTED_PREFIX = "fk_"
+
+    def __init__(self, code="CV14", description="", **kwargs):
+        """Initialize the rule with configuration."""
+        super().__init__(code=code, description=description, **kwargs)
+        # Set default expected_prefix if not provided
+        self.expected_prefix = kwargs.get(
+            "expected_prefix", self._DEFAULT_EXPECTED_PREFIX
+        )
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        """Validate FOREIGN KEY constraint name prefixes."""
+        try:
+            segment = context.segment
+            obj_ref = segment.get_child("object_reference")
+            if not obj_ref:
+                return None
+
+            constraint_name = obj_ref.raw
+            keywords = [
+                keyword.raw.upper() for keyword in segment.get_children("keyword")
+            ]
+
+            # Check if this is a FOREIGN KEY constraint
+            is_foreign_key = {"FOREIGN", "KEY"}.issubset(keywords)
+
+            if is_foreign_key and not constraint_name.lower().startswith(
+                self.expected_prefix
+            ):
+                return self._create_lint_result(
+                    segment, constraint_name, self.expected_prefix
+                )
+            return None
+        except Exception as e:
+            self.logger.error(f"Exception in constraint naming rule: {str(e)}")
+            return None
+
+    def _create_lint_result(
+        self, segment, constraint_name: str, expected_prefix: str
+    ) -> LintResult:
+        """Create a lint result for a constraint naming violation.
+
+        Args:
+            segment: The segment to anchor the lint result to
+            constraint_name: The name of the constraint
+            expected_prefix: The expected prefix for the constraint
+
+        Returns:
+            LintResult: The lint result object
+        """
+        self.logger.debug(
+            f"FOREIGN KEY constraint '{constraint_name}' violates convention"
+        )
+        return LintResult(
+            anchor=segment,
+            description=(
+                f"FOREIGN KEY constraint name '{constraint_name}' should start with "
+                f"'{expected_prefix}'."
+            ),
+        )

--- a/src/sqlfluff/rules/convention/CV15.py
+++ b/src/sqlfluff/rules/convention/CV15.py
@@ -1,0 +1,100 @@
+"""Implementation of Rule CV15."""
+
+from typing import Optional
+
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+
+class Rule_CV15(BaseRule):
+    """CHECK constraint names should use expected prefix.
+
+    **Anti-pattern**
+
+    .. code-block:: sql
+
+        CREATE TABLE public.employee (
+            employee_id INT,
+            salary DECIMAL(10,2),
+            CONSTRAINT salary_positive CHECK (salary > 0)
+        );
+
+    **Best practice**
+
+    .. code-block:: sql
+
+        CREATE TABLE public.employee (
+            employee_id INT,
+            salary DECIMAL(10,2),
+            CONSTRAINT chk_salary_positive CHECK (salary > 0)
+        );
+    """
+
+    name = "convention.constraint_name.check"
+    code = "CV15"
+    description = "Enforces CHECK constraints to start with expected prefix."
+    groups = ("all", "convention")
+    config_keywords = []  # Intentionally empty to bypass validation
+    crawl_behaviour = SegmentSeekerCrawler({"table_constraint"})
+
+    # The expected prefix for CHECK constraint
+    _DEFAULT_EXPECTED_PREFIX = "chk_"
+
+    def __init__(self, code="CV15", description="", **kwargs):
+        """Initialize the rule with configuration."""
+        super().__init__(code=code, description=description, **kwargs)
+        # Set default expected_prefix if not provided
+        self.expected_prefix = kwargs.get(
+            "expected_prefix", self._DEFAULT_EXPECTED_PREFIX
+        )
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        """Validate CHECK constraint name prefixes."""
+        try:
+            segment = context.segment
+            obj_ref = segment.get_child("object_reference")
+            if not obj_ref:
+                return None
+
+            constraint_name = obj_ref.raw
+            keywords = [
+                keyword.raw.upper() for keyword in segment.get_children("keyword")
+            ]
+
+            # Check if this is a CHECK constraint
+            is_check = "CHECK" in keywords
+
+            if is_check and not constraint_name.lower().startswith(
+                self.expected_prefix
+            ):
+                return self._create_lint_result(
+                    segment, constraint_name, self.expected_prefix
+                )
+            return None
+        except Exception as e:
+            self.logger.error(f"Exception in constraint naming rule: {str(e)}")
+            return None
+
+    def _create_lint_result(
+        self, segment, constraint_name: str, expected_prefix: str
+    ) -> LintResult:
+        """Create a lint result for a constraint naming violation.
+
+        Args:
+            segment: The segment to anchor the lint result to
+            constraint_name: The name of the constraint
+            expected_prefix: The expected prefix for the constraint
+
+        Returns:
+            LintResult: The lint result object
+        """
+        self.logger.debug(
+            f"CHECK constraint '{constraint_name}' violates naming convention"
+        )
+        return LintResult(
+            anchor=segment,
+            description=(
+                f"CHECK constraint name '{constraint_name}' should start with "
+                f"'{expected_prefix}'."
+            ),
+        )

--- a/src/sqlfluff/rules/convention/CV16.py
+++ b/src/sqlfluff/rules/convention/CV16.py
@@ -1,0 +1,100 @@
+"""Implementation of Rule CV16."""
+
+from typing import Optional
+
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+
+class Rule_CV16(BaseRule):
+    """UNIQUE constraint names should use expected prefix.
+
+    **Anti-pattern**
+
+    .. code-block:: sql
+
+        CREATE TABLE public.person (
+            person_id INT,
+            email TEXT,
+            CONSTRAINT email_unique UNIQUE (email)
+        );
+
+    **Best practice**
+
+    .. code-block:: sql
+
+        CREATE TABLE public.person (
+            person_id INT,
+            email TEXT,
+            CONSTRAINT uc_email UNIQUE (email)
+        );
+    """
+
+    name = "convention.constraint_name.unique"
+    code = "CV16"
+    description = "Enforces UNIQUE constraints to start with expected prefix."
+    groups = ("all", "convention")
+    config_keywords = []  # Intentionally empty to bypass validation
+    crawl_behaviour = SegmentSeekerCrawler({"table_constraint"})
+
+    # The expected prefix for UNIQUE constraint
+    _DEFAULT_EXPECTED_PREFIX = "uc_"
+
+    def __init__(self, code="CV16", description="", **kwargs):
+        """Initialize the rule with configuration."""
+        super().__init__(code=code, description=description, **kwargs)
+        # Set default expected_prefix if not provided
+        self.expected_prefix = kwargs.get(
+            "expected_prefix", self._DEFAULT_EXPECTED_PREFIX
+        )
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        """Validate UNIQUE constraint name prefixes."""
+        try:
+            segment = context.segment
+            obj_ref = segment.get_child("object_reference")
+            if not obj_ref:
+                return None
+
+            constraint_name = obj_ref.raw
+            keywords = [
+                keyword.raw.upper() for keyword in segment.get_children("keyword")
+            ]
+
+            # Check if this is a UNIQUE constraint
+            is_unique = "UNIQUE" in keywords
+
+            if is_unique and not constraint_name.lower().startswith(
+                self.expected_prefix
+            ):
+                return self._create_lint_result(
+                    segment, constraint_name, self.expected_prefix
+                )
+            return None
+        except Exception as e:
+            self.logger.error(f"Exception in constraint naming rule: {str(e)}")
+            return None
+
+    def _create_lint_result(
+        self, segment, constraint_name: str, expected_prefix: str
+    ) -> LintResult:
+        """Create a lint result for a constraint naming violation.
+
+        Args:
+            segment: The segment to anchor the lint result to
+            constraint_name: The name of the constraint
+            expected_prefix: The expected prefix for the constraint
+
+        Returns:
+            LintResult: The lint result object
+        """
+        self.logger.debug(
+            f"UNIQUE constraint '{constraint_name}' violates naming convention"
+        )
+        return LintResult(
+            anchor=segment,
+            description=(
+                f"UNIQUE constraint name '{constraint_name}' should start with "
+                f"'{expected_prefix}'."
+            ),
+        )

--- a/src/sqlfluff/rules/convention/CV17.py
+++ b/src/sqlfluff/rules/convention/CV17.py
@@ -1,0 +1,175 @@
+"""Implementation of Rule CV17."""
+
+from typing import Optional, Tuple
+
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+
+class Rule_CV17(BaseRule):
+    """DEFAULT constraint names should use expected prefix.
+
+    In PostgreSQL, DEFAULT can be used in two ways:
+    1. As a column property without a name (most common)
+    2. As a named constraint with the CONSTRAINT keyword (less common)
+
+    This rule only applies when DEFAULT is used with the CONSTRAINT keyword.
+
+    **Anti-pattern**
+
+    .. code-block:: sql
+
+        -- Named DEFAULT constraints should use the df_ prefix
+        CREATE TABLE public.person (
+            person_id INT,
+            created_at TIMESTAMP CONSTRAINT default_created_at
+                DEFAULT (CURRENT_TIMESTAMP)
+        );
+
+    **Best practice**
+
+    .. code-block:: sql
+
+        -- Use the df_ prefix for named DEFAULT constraints
+        CREATE TABLE public.person (
+            person_id INT,
+            created_at TIMESTAMP CONSTRAINT df_created_at
+                DEFAULT (CURRENT_TIMESTAMP)
+        );
+
+        -- DEFAULT without CONSTRAINT keyword is not checked by this rule
+        CREATE TABLE public.employee (
+            employee_id INT,
+            is_active BOOLEAN DEFAULT FALSE
+        );
+
+        -- ALTER COLUMN SET DEFAULT is also not checked by this rule
+        ALTER TABLE public.employee
+        ALTER COLUMN is_active SET DEFAULT TRUE;
+    """
+
+    name = "convention.constraint_name.default"
+    code = "CV17"
+    description = "Enforces named DEFAULT constraints to start with expected prefix."
+    groups = ("all", "convention")
+    config_keywords = []  # Intentionally empty to bypass validation
+    # DEFAULT constraints can appear in column definitions
+    crawl_behaviour = SegmentSeekerCrawler({"naked_identifier", "object_reference"})
+
+    # The expected prefix for DEFAULT constraint
+    _DEFAULT_EXPECTED_PREFIX = "df_"
+
+    def __init__(self, code="CV17", description="", **kwargs):
+        """Initialize the rule with configuration."""
+        super().__init__(code=code, description=description, **kwargs)
+        # Set default expected_prefix if not provided
+        self.expected_prefix = kwargs.get(
+            "expected_prefix", self._DEFAULT_EXPECTED_PREFIX
+        )
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        """Validate DEFAULT constraint name prefixes.
+
+        This rule only checks explicitly named DEFAULT constraints with
+        the CONSTRAINT keyword. DEFAULT as a column property (without a name)
+        is not checked.
+        """
+        try:
+            segment = context.segment
+            constraint_name = segment.raw.lower()
+
+            # Check if this segment is a constraint name
+            is_constraint_name, constraint_name = self._is_constraint_name(context)
+
+            if is_constraint_name:
+                # Check for DEFAULT keyword after constraint name
+                parent = context.parent_stack[-1] if context.parent_stack else None
+                if parent:
+                    for i, child in enumerate(parent.segments):
+                        if child is segment:
+                            # Look ahead for DEFAULT keyword
+                            next_seg_limit = min(i + 10, len(parent.segments))
+                            for j in range(i + 1, next_seg_limit):
+                                next_seg = parent.segments[j]
+                                keyword_match = (
+                                    next_seg.is_type("keyword")
+                                    and next_seg.raw.upper() == "DEFAULT"
+                                )
+                                if keyword_match:
+                                    if not constraint_name.startswith(
+                                        self.expected_prefix
+                                    ):
+                                        return self._create_lint_result(
+                                            segment,
+                                            constraint_name,
+                                            self.expected_prefix,
+                                        )
+                                    break
+                                type_check = not next_seg.is_type(
+                                    "whitespace"
+                                ) and not next_seg.is_type("type")
+                                if type_check:
+                                    # If not whitespace or type, and not DEFAULT,
+                                    # this is not a DEFAULT constraint
+                                    break
+
+            return None
+        except Exception as e:
+            self.logger.error(f"Exception in constraint naming rule: {str(e)}")
+            return None
+
+    def _is_constraint_name(self, context: RuleContext) -> Tuple[bool, str]:
+        """Check if the current segment is a constraint name.
+
+        Only identifies constraint names that follow the CONSTRAINT keyword.
+
+        Returns:
+            Tuple[bool, str]: A tuple with (is_constraint_name, constraint_name)
+        """
+        segment = context.segment
+        constraint_name = segment.raw.lower()
+
+        # Get the parent and check if it has a keyword before this segment
+        parent = context.parent_stack[-1] if context.parent_stack else None
+        if parent:
+            # Check if segment is preceded by the CONSTRAINT keyword
+            for i, child in enumerate(parent.segments):
+                if child is segment and i > 0:
+                    # Look at previous segment(s)
+                    prev_idx = i - 1
+                    while prev_idx >= 0:
+                        prev = parent.segments[prev_idx]
+                        is_constraint = (
+                            prev.is_type("keyword") and prev.raw.upper() == "CONSTRAINT"
+                        )
+                        if is_constraint:
+                            self.logger.debug(f"Found constraint name: {segment.raw}")
+                            return True, constraint_name
+                        elif not prev.is_type("whitespace"):
+                            break
+                        prev_idx -= 1
+                    break
+
+        return False, constraint_name
+
+    def _create_lint_result(
+        self, segment, constraint_name: str, expected_prefix: str
+    ) -> LintResult:
+        """Create a lint result for a constraint naming violation.
+
+        Args:
+            segment: The segment to anchor the lint result to
+            constraint_name: The name of the constraint
+            expected_prefix: The expected prefix for the constraint
+
+        Returns:
+            LintResult: The lint result object
+        """
+        self.logger.debug(f"DEFAULT constraint '{constraint_name}' violates convention")
+        return LintResult(
+            anchor=segment,
+            description=(
+                f"DEFAULT constraint name '{constraint_name}' should start with "
+                f"'{expected_prefix}'."
+            ),
+        )

--- a/src/sqlfluff/rules/convention/__init__.py
+++ b/src/sqlfluff/rules/convention/__init__.py
@@ -56,6 +56,13 @@ def get_configs_info() -> dict[str, ConfigInfo]:
             "validation": ["consistent", "shorthand", "convert", "cast"],
             "definition": ("The expectation for using sql type casting"),
         },
+        "expected_prefix": {
+            "definition": (
+                "Expected prefix for constraint naming rules. Default values are "
+                "'pk_' for PRIMARY KEY, 'fk_' for FOREIGN KEY, 'chk_' for CHECK, "
+                "'uc_' for UNIQUE, and 'df_' for DEFAULT constraints."
+            ),
+        },
     }
 
 
@@ -78,6 +85,11 @@ def get_rules() -> list[type[BaseRule]]:
     from sqlfluff.rules.convention.CV10 import Rule_CV10
     from sqlfluff.rules.convention.CV11 import Rule_CV11
     from sqlfluff.rules.convention.CV12 import Rule_CV12
+    from sqlfluff.rules.convention.CV13 import Rule_CV13
+    from sqlfluff.rules.convention.CV14 import Rule_CV14
+    from sqlfluff.rules.convention.CV15 import Rule_CV15
+    from sqlfluff.rules.convention.CV16 import Rule_CV16
+    from sqlfluff.rules.convention.CV17 import Rule_CV17
 
     return [
         Rule_CV01,
@@ -92,4 +104,9 @@ def get_rules() -> list[type[BaseRule]]:
         Rule_CV10,
         Rule_CV11,
         Rule_CV12,
+        Rule_CV13,
+        Rule_CV14,
+        Rule_CV15,
+        Rule_CV16,
+        Rule_CV17,
     ]

--- a/test/rules/std_CV13_test.py
+++ b/test/rules/std_CV13_test.py
@@ -1,0 +1,70 @@
+"""Tests for the CV13 rule (PRIMARY KEY constraint naming)."""
+
+import pytest
+
+from sqlfluff.core import Linter
+from sqlfluff.core.config import FluffConfig
+
+
+@pytest.fixture(scope="module")
+def pk_linter():
+    """Create a linter with the PRIMARY KEY constraint rule enabled."""
+    config = FluffConfig(
+        configs={
+            "core": {"dialect": "postgres"},
+            "rules": {"CV13": {"enabled": True}},
+            "include_rules": ["CV13"],
+            "exclude_rules": ["all"],
+        }
+    )
+    return Linter(config=config)
+
+
+def test_primary_key_valid(pk_linter):
+    """Test that a valid primary key constraint name passes when creating a table."""
+    sql = """
+    CREATE TABLE public.person (
+        person_id INT,
+        CONSTRAINT pk_person PRIMARY KEY (person_id)
+    );
+    """
+    result = pk_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV13"]
+    assert len(violations) == 0
+
+
+def test_primary_key_invalid(pk_linter):
+    """Test that an invalid primary key constraint name passes when creating a table."""
+    sql = """
+    CREATE TABLE public.person (
+        person_id INT,
+        CONSTRAINT person_pk PRIMARY KEY (person_id)
+    );
+    """
+    result = pk_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV13"]
+    assert len(violations) == 1
+    assert "should start with 'pk_'" in violations[0].description.lower()
+
+
+def test_add_primary_key_valid(pk_linter):
+    """Test that a valid primary key constraint name passes when altering a table."""
+    sql = """
+    ALTER TABLE public.person
+    ADD CONSTRAINT pk_person PRIMARY KEY (person_id);
+    """
+    result = pk_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV13"]
+    assert len(violations) == 0
+
+
+def test_add_primary_key_invalid(pk_linter):
+    """Test that an invalid primary key constraint name passes when altering a table."""
+    sql = """
+    ALTER TABLE public.person
+    ADD CONSTRAINT person_pk PRIMARY KEY (person_id);
+    """
+    result = pk_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV13"]
+    assert len(violations) == 1
+    assert "should start with 'pk_'" in violations[0].description.lower()

--- a/test/rules/std_CV14_test.py
+++ b/test/rules/std_CV14_test.py
@@ -1,0 +1,76 @@
+"""Tests for the CV14 rule (FOREIGN KEY constraint naming)."""
+
+import pytest
+
+from sqlfluff.core import Linter
+from sqlfluff.core.config import FluffConfig
+
+
+@pytest.fixture(scope="module")
+def fk_linter():
+    """Create a linter with the FOREIGN KEY constraint rule enabled."""
+    config = FluffConfig(
+        configs={
+            "core": {"dialect": "postgres"},
+            "rules": {"CV14": {"enabled": True}},
+            "include_rules": ["CV14"],
+            "exclude_rules": ["all"],
+        }
+    )
+    return Linter(config=config)
+
+
+def test_foreign_key_valid(fk_linter):
+    """Test that a valid foreign key constraint name passes when creating a table."""
+    sql = """
+    CREATE TABLE public.orders (
+        order_id INT,
+        person_id INT,
+        CONSTRAINT fk_orders_person FOREIGN KEY (person_id)
+            REFERENCES public.person(person_id)
+    );
+    """
+    result = fk_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV14"]
+    assert len(violations) == 0
+
+
+def test_foreign_key_invalid(fk_linter):
+    """Test that an invalid foreign key constraint name fails when creating a table."""
+    sql = """
+    CREATE TABLE public.orders (
+        order_id INT,
+        person_id INT,
+        CONSTRAINT orders_person_fk FOREIGN KEY (person_id)
+            REFERENCES public.person(person_id)
+    );
+    """
+    result = fk_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV14"]
+    assert len(violations) == 1
+    assert "should start with 'fk_'" in violations[0].description.lower()
+
+
+def test_add_foreign_key_valid(fk_linter):
+    """Test that a valid foreign key constraint name passes when altering a table."""
+    sql = """
+    ALTER TABLE public.orders
+    ADD CONSTRAINT fk_orders_person FOREIGN KEY (person_id)
+        REFERENCES public.person(person_id);
+    """
+    result = fk_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV14"]
+    assert len(violations) == 0
+
+
+def test_add_foreign_key_invalid(fk_linter):
+    """Test that an invalid foreign key constraint name fails when altering a table."""
+    sql = """
+    ALTER TABLE public.orders
+    ADD CONSTRAINT orders_person_fk FOREIGN KEY (person_id)
+        REFERENCES public.person(person_id);
+    """
+    result = fk_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV14"]
+    assert len(violations) == 1
+    assert "should start with 'fk_'" in violations[0].description.lower()

--- a/test/rules/std_CV15_test.py
+++ b/test/rules/std_CV15_test.py
@@ -1,0 +1,72 @@
+"""Tests for the CV15 rule (CHECK constraint naming)."""
+
+import pytest
+
+from sqlfluff.core import Linter
+from sqlfluff.core.config import FluffConfig
+
+
+@pytest.fixture
+def chk_linter():
+    """Create a linter with the CHECK constraint rule enabled."""
+    config = FluffConfig(
+        configs={
+            "core": {"dialect": "postgres"},
+            "rules": {"CV15": {"enabled": True}},
+            "include_rules": ["CV15"],
+            "exclude_rules": ["all"],
+        }
+    )
+    return Linter(config=config)
+
+
+def test_check_constraint_valid(chk_linter):
+    """Test that a valid check constraint name passes when creating a table."""
+    sql = """
+    CREATE TABLE public.person (
+        person_id INT,
+        age INT,
+        CONSTRAINT chk_person_age CHECK (age > 0)
+    );
+    """
+    result = chk_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV15"]
+    assert len(violations) == 0
+
+
+def test_check_constraint_invalid(chk_linter):
+    """Test that an invalid check constraint name fails when creating a table."""
+    sql = """
+    CREATE TABLE public.person (
+        person_id INT,
+        age INT,
+        CONSTRAINT age_positive CHECK (age > 0)
+    );
+    """
+    result = chk_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV15"]
+    assert len(violations) == 1
+    assert "should start with 'chk_'" in violations[0].description.lower()
+
+
+def test_add_check_valid(chk_linter):
+    """Test that a valid check constraint name passes when altering a table."""
+    sql = """
+    ALTER TABLE public.person
+    ADD CONSTRAINT chk_person_age CHECK (age > 0);
+    """
+    result = chk_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV15"]
+    assert len(violations) == 0
+
+
+def test_add_check_invalid(chk_linter):
+    """Test that an invalid check constraint name fails when altering a table."""
+    sql = """
+    ALTER TABLE public.person
+    ADD CONSTRAINT age_positive CHECK (age > 0);
+    """
+    result = chk_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV15"]
+    assert len(violations) == 1
+    assert "should start with 'chk_'" in violations[0].description.lower()

--- a/test/rules/std_CV16_test.py
+++ b/test/rules/std_CV16_test.py
@@ -1,0 +1,85 @@
+"""Tests for the CV16 rule (UNIQUE constraint naming)."""
+
+import pytest
+
+from sqlfluff.core import Linter
+from sqlfluff.core.config import FluffConfig
+
+
+@pytest.fixture
+def uc_linter():
+    """Create a linter with the UNIQUE constraint rule enabled."""
+    config = FluffConfig(
+        configs={
+            "core": {"dialect": "postgres"},
+            "rules": {"CV16": {"enabled": True}},
+            "include_rules": ["CV16"],
+            "exclude_rules": ["all"],
+        }
+    )
+    return Linter(config=config)
+
+
+def test_unique_constraint_valid(uc_linter):
+    """Test that a valid unique constraint name passes when creating a table."""
+    sql = """
+    CREATE TABLE public.person (
+        person_id INT,
+        email VARCHAR(255),
+        CONSTRAINT uc_person_email UNIQUE (email)
+    );
+    """
+    result = uc_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV16"]
+    assert len(violations) == 0
+
+
+def test_unique_constraint_invalid(uc_linter):
+    """Test that an invalid unique constraint name fails when creating a table."""
+    sql = """
+    CREATE TABLE public.person (
+        person_id INT,
+        email VARCHAR(255),
+        CONSTRAINT unique_email UNIQUE (email)
+    );
+    """
+    result = uc_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV16"]
+    assert len(violations) == 1
+    assert "should start with 'uc_'" in violations[0].description.lower()
+
+
+def test_inline_unique_constraint(uc_linter):
+    """Test inline unique constraint with valid name when creating a table."""
+    sql = """
+    CREATE TABLE public.person (
+        person_id INT,
+        email VARCHAR(255) CONSTRAINT uc_person_email UNIQUE
+    );
+    """
+    result = uc_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV16"]
+    assert len(violations) == 0
+
+
+def test_add_unique_valid(uc_linter):
+    """Test that a valid unique constraint name passes when altering a table."""
+    sql = """
+    ALTER TABLE public.person
+    ADD CONSTRAINT uc_person_email UNIQUE (email);
+    """
+    result = uc_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV16"]
+    assert len(violations) == 0
+
+
+def test_add_unique_invalid(uc_linter):
+    """Test that an invalid unique constraint name fails when altering a table."""
+    sql = """
+    ALTER TABLE public.person
+    ADD CONSTRAINT unique_email UNIQUE (email);
+    """
+    result = uc_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV16"]
+    assert len(violations) == 1
+    assert "should start with 'uc_'" in violations[0].description.lower()

--- a/test/rules/std_CV17_test.py
+++ b/test/rules/std_CV17_test.py
@@ -1,0 +1,47 @@
+"""Tests for the CV17 rule (DEFAULT constraint naming)."""
+
+import pytest
+
+from sqlfluff.core import Linter
+from sqlfluff.core.config import FluffConfig
+
+
+@pytest.fixture
+def df_linter():
+    """Create a linter with the DEFAULT constraint rule enabled."""
+    config = FluffConfig(
+        configs={
+            "core": {"dialect": "postgres"},
+            "rules": {"CV17": {"enabled": True}},
+            "include_rules": ["CV17"],
+            "exclude_rules": ["all"],
+        }
+    )
+    return Linter(config=config)
+
+
+def test_default_constraint_valid(df_linter):
+    """Test that a valid default constraint name passes when creating a table."""
+    sql = """
+    CREATE TABLE public.person (
+        person_id INT,
+        created_at TIMESTAMP CONSTRAINT df_person_created_at DEFAULT (CURRENT_TIMESTAMP)
+    );
+    """
+    result = df_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV17"]
+    assert len(violations) == 0
+
+
+def test_default_constraint_invalid(df_linter):
+    """Test that an invalid default constraint name fails when creating a table."""
+    sql = """
+    CREATE TABLE public.person (
+        person_id INT,
+        created_at TIMESTAMP CONSTRAINT default_created_at DEFAULT (CURRENT_TIMESTAMP)
+    );
+    """
+    result = df_linter.lint_string(sql)
+    violations = [v for v in result.violations if v.rule_code() == "CV17"]
+    assert len(violations) == 1
+    assert "should start with 'df_'" in violations[0].description.lower()


### PR DESCRIPTION
### Brief summary of the change made
This PR adds five new rules (CV13-CV17) that enforce consistent naming conventions for SQL database constraints. 

#### Rules Added

1. **CV13 (PRIMARY KEY constraint naming)**: Enforces PRIMARY KEY constraints to start with the `expected_prefix`
- Example: CONSTRAINT pk_person PRIMARY KEY (person_id)
2. **CV14 (FOREIGN KEY constraint naming)**: Enforces FOREIGN KEY constraints to start with the `expected_prefix`
Example: CONSTRAINT fk_customer_order FOREIGN KEY (customer_id) REFERENCES customers(id)
3. **CV15 (CHECK constraint naming)**: Enforces CHECK constraints to start with the `expected_prefix`
Example: CONSTRAINT chk_salary_positive CHECK (salary > 0)
4. **CV16 (UNIQUE constraint naming)**: Enforces UNIQUE constraints to start with the `expected_prefix`
Example: CONSTRAINT uc_email UNIQUE (email)
5. **CV17 (DEFAULT constraint naming)**: Enforces named DEFAULT constraints to start with the `expected_prefix`
Example: CONSTRAINT df_created_at DEFAULT (CURRENT_TIMESTAMP)
Note: This rule only applies to explicitly named DEFAULT constraints with the CONSTRAINT keyword

#### Features
- All naming prefixes are configurable through the rule configuration
- Docstrings with examples of anti-patterns and best practices
- Unit tests are for each rule

### Are there any other side effects of this change that we should be aware of?
Not that I am aware of.

### Pull Request checklist
- [*] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
